### PR TITLE
Only respond to GOMLs from the "main" channel.

### DIFF
--- a/__tests__/commands/goml.test.ts
+++ b/__tests__/commands/goml.test.ts
@@ -1,0 +1,40 @@
+import { DMChannel, TextChannel } from "discord.js";
+import goml from "../../src/commands/Goml";
+import DiscordClient from "../../src/DiscordClient";
+
+describe("Goml", () => {
+  const discordClient = new DiscordClient();
+  const sendMock = jest.fn();
+  discordClient.sendMessage = sendMock;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("goml", () => {
+    describe("should not send a message", () => {
+      test("when a 'goml' message was sent in a DM.", async () => {
+        const channel: Partial<DMChannel> = {};
+        await goml(discordClient, <DMChannel>channel);
+        expect(sendMock).toBeCalledTimes(0);
+      });
+
+      test("when a 'goml' message was not sent in the 'main' channel.", async () => {
+        // I think the fact that I have to define `valueOf` here is a bug
+        // or I'm just not understanding something about how `Partial` works here.
+        const channel: Partial<TextChannel> = { name: DiscordClient.CHANNELS.MAIN + "foo", valueOf: () => { return "why"; }};
+        await goml(discordClient, <TextChannel>channel);
+        expect(sendMock).toBeCalledTimes(0);
+      });
+    });
+
+    describe("should send a message", () => {
+      test("when a 'goml' message was sent in the 'main' channel.", async () => {
+        // Again more weirdness with `valueOf` and partial type definition here.
+        const channel: Partial<TextChannel> = { name: DiscordClient.CHANNELS.MAIN, valueOf: () => { return "why"; }};
+        await goml(discordClient, <TextChannel>channel);
+        expect(sendMock).toBeCalledTimes(1);
+      })
+    });
+  });
+});

--- a/src/NYTCrosswordPuzzleBot.ts
+++ b/src/NYTCrosswordPuzzleBot.ts
@@ -2,6 +2,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 import DiscordClient, { MESSAGES } from "./DiscordClient";
 import Cron, { CRON_INTERVALS } from "./Cron";
+import { DMChannel, Message } from "discord.js";
 
 const discordClient = new DiscordClient();
 
@@ -21,10 +22,11 @@ discordClient.on("ready", async () => {
   });
 });
 
-discordClient.on("message", async ({ content }) => {
+discordClient.on("message", async ({ content, channel }: Message) => {
   const parsedMessage = discordClient.parseMessage(content);
 
-  if (parsedMessage === "goml" || parsedMessage === "#goml") {
+  const isNytMiniChannel = (!(channel instanceof DMChannel) && channel.name === DiscordClient.CHANNELS.MAIN);
+  if (isNytMiniChannel && (parsedMessage === "goml" || parsedMessage === "#goml")) {
     await discordClient.sendMessage(MESSAGES.GOML, DiscordClient.CHANNELS.MAIN);
   }
 });

--- a/src/NYTCrosswordPuzzleBot.ts
+++ b/src/NYTCrosswordPuzzleBot.ts
@@ -2,6 +2,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 import DiscordClient, { MESSAGES } from "./DiscordClient";
 import Cron, { CRON_INTERVALS } from "./Cron";
+import goml from "./commands/Goml";
 import { DMChannel, Message } from "discord.js";
 
 const discordClient = new DiscordClient();
@@ -22,11 +23,10 @@ discordClient.on("ready", async () => {
   });
 });
 
-discordClient.on("message", async ({ content, channel }: Message) => {
-  const parsedMessage = discordClient.parseMessage(content);
+discordClient.on("message", async (message: Message) => {
+  const parsedMessage = discordClient.parseMessage(message.content);
 
-  const isNytMiniChannel = (!(channel instanceof DMChannel) && channel.name === DiscordClient.CHANNELS.MAIN);
-  if (isNytMiniChannel && (parsedMessage === "goml" || parsedMessage === "#goml")) {
-    await discordClient.sendMessage(MESSAGES.GOML, DiscordClient.CHANNELS.MAIN);
+  if (parsedMessage === "goml" || parsedMessage === "#goml") {
+    await goml(discordClient, message.channel);
   }
 });

--- a/src/NYTCrosswordPuzzleBot.ts
+++ b/src/NYTCrosswordPuzzleBot.ts
@@ -23,10 +23,10 @@ discordClient.on("ready", async () => {
   });
 });
 
-discordClient.on("message", async (message: Message) => {
-  const parsedMessage = discordClient.parseMessage(message.content);
+discordClient.on("message", async ({content, channel}: Message) => {
+  const parsedMessage = discordClient.parseMessage(content);
 
   if (parsedMessage === "goml" || parsedMessage === "#goml") {
-    await goml(discordClient, message.channel);
+    await goml(discordClient, channel);
   }
 });

--- a/src/NYTCrosswordPuzzleBot.ts
+++ b/src/NYTCrosswordPuzzleBot.ts
@@ -3,7 +3,7 @@ dotenv.config();
 import DiscordClient, { MESSAGES } from "./DiscordClient";
 import Cron, { CRON_INTERVALS } from "./Cron";
 import goml from "./commands/Goml";
-import { DMChannel, Message } from "discord.js";
+import { Message } from "discord.js";
 
 const discordClient = new DiscordClient();
 

--- a/src/commands/Goml.ts
+++ b/src/commands/Goml.ts
@@ -1,0 +1,10 @@
+import { DMChannel, NewsChannel, TextChannel } from "discord.js";
+import DiscordClient, { MESSAGES } from "../DiscordClient";
+
+async function goml(client: DiscordClient, channel: DMChannel | TextChannel | NewsChannel): Promise<void> {
+  if (channel instanceof DMChannel || channel.name !== DiscordClient.CHANNELS.MAIN) return;
+
+  await client.sendMessage(MESSAGES.GOML, channel.name);
+}
+
+export default goml;


### PR DESCRIPTION
Moves the logic for the `goml` command into a separate file and function to make testing easier.

Resolves awseale/discordBot#14